### PR TITLE
添加使用流方式上传文件 web-flux 接口

### DIFF
--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
@@ -9,12 +9,10 @@ import org.springframework.context.annotation.ComponentScan
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType.TEXT_PLAIN
 import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.function.server.ServerResponse
 import org.springframework.web.reactive.function.server.ServerResponse.ok
 import org.springframework.web.reactive.function.server.router
-import tech.simter.file.rest.webflux.handler.AttachmentFormHandler
-import tech.simter.file.rest.webflux.handler.AttachmentViewHandler
-import tech.simter.file.rest.webflux.handler.DownloadFileHandler
-import tech.simter.file.rest.webflux.handler.UploadFileHandler
+import tech.simter.file.rest.webflux.handler.*
 
 private const val MODULE = "tech.simter.file.rest.webflux"
 
@@ -34,6 +32,7 @@ class ModuleConfiguration @Autowired constructor(
   private val attachmentFormHandler: AttachmentFormHandler,
   private val attachmentViewHandler: AttachmentViewHandler,
   private val uploadFileByFormHandler: UploadFileByFormHandler,
+  private val uploadFileByStreamHandler: UploadFileByStreamHandler,
   private val downloadFileHandler: DownloadFileHandler
 ) {
   private val logger = LoggerFactory.getLogger(ModuleConfiguration::class.java)
@@ -49,6 +48,8 @@ class ModuleConfiguration @Autowired constructor(
     contextPath.nest {
       // POST /
       UploadFileByFormHandler.REQUEST_PREDICATE.invoke(uploadFileByFormHandler::handle)
+      // POST /
+      UploadFileByStreamHandler.REQUEST_PREDICATE.invoke(uploadFileByStreamHandler::handle)
       // GET /attachment?page-no=:pageNo&page-size=:pageSize
       AttachmentViewHandler.REQUEST_PREDICATE.invoke(attachmentViewHandler::handle)
       // GET /attachment/{id}

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
@@ -33,7 +33,7 @@ class ModuleConfiguration @Autowired constructor(
   @Value("\${simter.rest.context-path.file:/}") private val contextPath: String,
   private val attachmentFormHandler: AttachmentFormHandler,
   private val attachmentViewHandler: AttachmentViewHandler,
-  private val uploadFileHandler: UploadFileHandler,
+  private val uploadFileByFormHandler: UploadFileByFormHandler,
   private val downloadFileHandler: DownloadFileHandler
 ) {
   private val logger = LoggerFactory.getLogger(ModuleConfiguration::class.java)
@@ -48,7 +48,7 @@ class ModuleConfiguration @Autowired constructor(
   fun fileRoutes() = router {
     contextPath.nest {
       // POST /
-      UploadFileHandler.REQUEST_PREDICATE.invoke(uploadFileHandler::handle)
+      UploadFileByFormHandler.REQUEST_PREDICATE.invoke(uploadFileByFormHandler::handle)
       // GET /attachment?page-no=:pageNo&page-size=:pageSize
       AttachmentViewHandler.REQUEST_PREDICATE.invoke(attachmentViewHandler::handle)
       // GET /attachment/{id}

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByFormHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByFormHandler.kt
@@ -25,7 +25,7 @@ import kotlin.collections.HashMap
 
 
 /**
- * The [HandlerFunction] for upload file.
+ * The [HandlerFunction] for upload file by from.
  *
  * Request: (form submit with <input type="file">)
  *
@@ -57,18 +57,19 @@ import kotlin.collections.HashMap
  * Location : {context-path}/{id}
  * ```
  *
- * [More](https://github.com/simter/simter-file/wiki/Upload-One-File)
+ * [More](https://github.com/simter/simter-file/wiki/Upload-One-File-By-Form)
  *
  * @author JF
  * @author RJ
  */
 @Component
-class UploadFileHandler @Autowired constructor(
+class UploadFileByFormHandler @Autowired constructor(
   @Value("\${simter.file.root}") private val fileRootDir: String,
   private val attachmentService: AttachmentService
 ) : HandlerFunction<ServerResponse> {
 
   override fun handle(request: ServerRequest): Mono<ServerResponse> {
+    val a = request.bodyToFlux(Part::class.java)
     return request
       .bodyToFlux(Part::class.java)
       .filter({ it is FilePart || it is FormFieldPart })

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByStreamHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByStreamHandler.kt
@@ -1,0 +1,123 @@
+package tech.simter.file.rest.webflux.handler
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Component
+import org.springframework.util.FileCopyUtils
+import org.springframework.web.reactive.function.server.HandlerFunction
+import org.springframework.web.reactive.function.server.RequestPredicate
+import org.springframework.web.reactive.function.server.RequestPredicates.POST
+import org.springframework.web.reactive.function.server.RequestPredicates.contentType
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+import reactor.core.publisher.toMono
+import tech.simter.file.po.Attachment
+import tech.simter.file.service.AttachmentService
+import java.io.File
+import java.net.URI
+import java.time.OffsetDateTime
+import java.time.format.DateTimeFormatter
+import java.util.*
+import kotlin.collections.HashMap
+
+
+/**
+ * The [HandlerFunction] for upload file by stream.
+ *
+ * Request: (form submit with <input type="file">)
+ *
+ * ```
+ * POST {context-path}?puid=xxx&subgroup=xxx
+ * Content-Type        : application/octet-stream
+ * Content-Length      : {len}
+ * Content-Disposition : {fileName}
+ *
+ * {file-data}
+ * ```
+ *
+ * Response:
+ *
+ * ```
+ * 204 No Content
+ * Location : {context-path}/{id}
+ * ```
+ *
+ * [More](https://github.com/simter/simter-file/wiki/Upload-One-File-By-Stream)
+ *
+ * @author JW
+ */
+@Component
+class UploadFileByStreamHandler @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
+  private val attachmentService: AttachmentService
+) : HandlerFunction<ServerResponse> {
+
+  override fun handle(request: ServerRequest): Mono<ServerResponse> {
+    return request
+      .bodyToFlux(ByteArray::class.java)
+      // 1. extract data in request body
+      .map({
+        // build Map by data in list
+        val formDataMap = HashMap<String, Any>()
+        formDataMap["filename"] = request.headers().header("Content-Disposition")[0]
+        formDataMap["puid"] = request.queryParam("puid")
+          .orElseThrow { NullPointerException("Parameter \"puid\" mustn't be null!") }
+        formDataMap["subgroup"] = request.queryParam("subgroup")
+          .orElseThrow { NullPointerException("Parameter \"subgroup\" mustn't be null!") }.toShort()
+        formDataMap["fileData"] = it
+        formDataMap
+      })
+      // 2. save file to disk
+      .flatMap({
+        // get the FilePart by the Map
+        val fileData = it["fileData"] as ByteArray
+        // convert to Attachment instance
+        val attachment = toAttachment(fileData.size.toLong(), it["filename"] as String, it["puid"] as String, it["subgroup"] as Short)
+
+        val file = File("$fileRootDir/${attachment.path}")
+        val fileDir = file.parentFile
+        if (!fileDir.exists()) {
+          if (!fileDir.mkdirs())  // create file directory if not exists
+            throw IllegalAccessException("Failed to create parents dir: ${fileDir.absolutePath}")
+        }
+        if (!file.createNewFile()) throw IllegalAccessException("Failed to create file: ${file.absolutePath}")
+
+        // save to disk
+        Mono.just(FileCopyUtils.copy(fileData, file))
+          .then(Mono.just(if (attachment.size != -1L) attachment else attachment.copy(size = file.length())))
+      })
+      // 3. save attachment
+      .flatMap({ attachmentService.save(it).thenReturn(it) })
+      // 4. return response
+      .flatMap({ ServerResponse.noContent().location(URI.create("/${it.id}")).build() }).toMono()
+  }
+
+  private fun toAttachment(fileSize: Long, filename: String, puid: String, subgroup: Short): Attachment {
+    val id = newId()
+    val now = OffsetDateTime.now()
+    val lastDotIndex = filename.lastIndexOf(".")
+    val ext = filename.substring(lastDotIndex + 1)
+    val path = "${now.format(DateTimeFormatter.ofPattern("yyyyMM"))}/${now.format(DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"))}-$id.$ext"
+    return Attachment(
+      id,                                     // id
+      path,                                   // relative path
+      filename.substring(0, lastDotIndex),    // name
+      ext,                                    // ext
+      fileSize,                               // file size
+      now,                                    // upload time
+      "Simter",                               // uploader
+      puid,                                   // puid
+      subgroup                                // subgroup
+    )
+  }
+
+  /** Generate a new [Attachment] id */
+  fun newId() = UUID.randomUUID().toString()
+
+  companion object {
+    /** The default [RequestPredicate] */
+    val REQUEST_PREDICATE: RequestPredicate = POST("/").and(contentType(MediaType.APPLICATION_OCTET_STREAM))
+  }
+}

--- a/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByFormHandlerTest.kt
+++ b/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByFormHandlerTest.kt
@@ -18,7 +18,7 @@ import org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFu
 import org.springframework.web.reactive.config.EnableWebFlux
 import org.springframework.web.reactive.function.server.RouterFunctions.route
 import reactor.core.publisher.Mono
-import tech.simter.file.rest.webflux.handler.UploadFileHandler.Companion.REQUEST_PREDICATE
+import tech.simter.file.rest.webflux.handler.UploadFileByFormHandler.Companion.REQUEST_PREDICATE
 import tech.simter.file.service.AttachmentService
 import java.io.File
 import java.io.IOException
@@ -28,22 +28,22 @@ import java.time.temporal.ChronoUnit.SECONDS
 import java.util.*
 
 /**
- * Test UploadFileHandler.
+ * Test UploadFileByFormHandler.
  *
  * @author JF
  * @author RJ
  */
-@SpringJUnitConfig(UploadFileHandler::class)
+@SpringJUnitConfig(UploadFileByFormHandler::class)
 @EnableWebFlux
 @MockBean(AttachmentService::class)
-@SpyBean(UploadFileHandler::class)
+@SpyBean(UploadFileByFormHandler::class)
 @TestPropertySource(properties = ["simter.file.root=target/files"])
-internal class UploadFileHandlerTest @Autowired constructor(
+internal class UploadFileByFormHandlerTest @Autowired constructor(
   private val service: AttachmentService,
   @Value("\${simter.file.root}") private val fileRootDir: String,
-  private val handler: UploadFileHandler
+  private val byFormHandler: UploadFileByFormHandler
 ) {
-  private val client = bindToRouterFunction(route(REQUEST_PREDICATE, handler)).build()
+  private val client = bindToRouterFunction(route(REQUEST_PREDICATE, byFormHandler)).build()
 
   @Test
   @Throws(IOException::class)
@@ -63,8 +63,8 @@ internal class UploadFileHandlerTest @Autowired constructor(
     val fileSize = file.contentLength()
     `when`(service.save(any())).thenReturn(Mono.empty())
 
-    // mock handler.newId return value
-    `when`(handler.newId()).thenReturn(id)
+    // mock byFormHandler.newId return value
+    `when`(byFormHandler.newId()).thenReturn(id)
 
     // invoke request
     val now = LocalDateTime.now().truncatedTo(SECONDS)

--- a/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByStreamHandlerTest.kt
+++ b/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByStreamHandlerTest.kt
@@ -1,0 +1,100 @@
+package tech.simter.file.rest.webflux.handler
+
+import com.nhaarman.mockito_kotlin.any
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.`when`
+import org.mockito.Mockito.verify
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.SpyBean
+import org.springframework.core.io.ClassPathResource
+import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFunction
+import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.function.server.RouterFunctions.route
+import reactor.core.publisher.Mono
+import tech.simter.file.rest.webflux.handler.UploadFileByStreamHandler.Companion.REQUEST_PREDICATE
+import tech.simter.file.service.AttachmentService
+import java.io.File
+import java.io.IOException
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit.SECONDS
+import java.util.*
+
+/**
+ * Test UploadFileByStreamHandler.
+ *
+ * @author JW
+ */
+@SpringJUnitConfig(UploadFileByStreamHandler::class)
+@EnableWebFlux
+@MockBean(AttachmentService::class)
+@SpyBean(UploadFileByStreamHandler::class)
+@TestPropertySource(properties = ["simter.file.root=target/files"])
+internal class UploadFileByStreamHandlerTest @Autowired constructor(
+  private val service: AttachmentService,
+  @Value("\${simter.file.root}") private val fileRootDir: String,
+  private val uploadFileByStreamHandler: UploadFileByStreamHandler
+) {
+  private val client = bindToRouterFunction(route(REQUEST_PREDICATE, uploadFileByStreamHandler)).build()
+
+  @Test
+  @Throws(IOException::class)
+  fun upload() {
+    // mock MultipartBody
+    val name = "logback-test"
+    val ext = "xml"
+    val file = ClassPathResource("$name.$ext")
+
+    // mock service.create return value
+    val id = UUID.randomUUID().toString()
+    val fileSize = file.contentLength()
+    `when`(service.save(any())).thenReturn(Mono.empty())
+
+    // mock uploadFileByStreamHandler.newId return value
+    `when`(uploadFileByStreamHandler.newId()).thenReturn(id)
+
+    // invoke request
+    val now = LocalDateTime.now().truncatedTo(SECONDS)
+    client.post().uri("/?puid=puid1&subgroup=1")
+      .header("Content-Disposition","$name.$ext")
+      .contentType(MediaType.APPLICATION_OCTET_STREAM)
+      .contentLength(fileSize)
+      .syncBody(file.file.readBytes())
+      .exchange()
+      .expectStatus().isNoContent
+      .expectHeader().valueEquals("Location", "/$id")
+
+    // 1. verify service.save method invoked
+    verify(service).save(any())
+
+    // 2. verify the saved file exists
+    val yyyyMM = now.format(DateTimeFormatter.ofPattern("yyyyMM"))
+    val files = File("$fileRootDir/$yyyyMM").listFiles()
+    assertNotNull(files)
+    assertTrue(files.isNotEmpty())
+    var actualFile: File? = null
+    for (f in files) {
+      // extract dateTime and id from fileName: yyyyMMddTHHmmss-{id}.{ext}
+      val index = f.name.indexOf("-")
+      val dateTime = LocalDateTime.parse(f.name.substring(0, index),
+        DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss"))
+      val uuid = f.name.substring(index + 1, f.name.lastIndexOf("."))
+      if (id == uuid && !dateTime.isBefore(now)) {
+        actualFile = f
+        break
+      }
+    }
+    assertNotNull(actualFile)
+
+    // 3. verify the saved file size
+    assertEquals(actualFile!!.length(), fileSize)
+
+    // 4. TODO verify the attachment
+  }
+}


### PR DESCRIPTION
本次 PR 主要修改以下内容：

1. 将 UploadFileHandler 类重命名为 UploadFileByFormHandler 和其他相关代码的修改。
2. 新增 UploadFileByStreamHandler 类实现使用流上传文件。