### PR TITLE
补充修正按流方式上传文件 web-flux 接口

### DIFF
--- a/simter-file-data/src/main/resources/tech/simter/file/sql/postgres/schema-create.sql
+++ b/simter-file-data/src/main/resources/tech/simter/file/sql/postgres/schema-create.sql
@@ -8,7 +8,7 @@ create table st_attachment (
   name varchar(255) not null,
   ext varchar(10) not null,
   size integer not null,
-  uploadOn timestampz not null,
+  upload_on timestamp not null,
   uploader varchar(255) not null,
   puid varchar(36) not null default '0',
   subgroup integer not null default 0

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
@@ -58,6 +58,8 @@ class ModuleConfiguration @Autowired constructor(
       DownloadFileHandler.REQUEST_PREDICATE.invoke(downloadFileHandler::handle)
       // GET /
       GET("/", { ok().contentType(TEXT_PLAIN).syncBody("simter-file module") })
+      // OPTIONS /*
+      OPTIONS("/**", { ServerResponse.noContent().build() })
     }
   }
 }

--- a/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByStreamHandlerTest.kt
+++ b/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/UploadFileByStreamHandlerTest.kt
@@ -62,7 +62,7 @@ internal class UploadFileByStreamHandlerTest @Autowired constructor(
     // invoke request
     val now = LocalDateTime.now().truncatedTo(SECONDS)
     client.post().uri("/?puid=puid1&subgroup=1")
-      .header("Content-Disposition","$name.$ext")
+      .header("Content-Disposition","attachment; name=\"filedata\"; filename=\"$$name.$ext\"")
       .contentType(MediaType.APPLICATION_OCTET_STREAM)
       .contentLength(fileSize)
       .syncBody(file.file.readBytes())

--- a/simter-file-starter/src/main/kotlin/tech/simter/file/starter/webflux/WebFluxConfiguration.kt
+++ b/simter-file-starter/src/main/kotlin/tech/simter/file/starter/webflux/WebFluxConfiguration.kt
@@ -30,7 +30,7 @@ class WebFluxConfiguration : WebFluxConfigurer {
     registry!!.addMapping("/**")
       .allowedOrigins("*")
       .allowedMethods("*")
-      .allowedHeaders("Authorization")
+      .allowedHeaders("Authorization", "Content-Type", "Content-Disposition")
       //.exposedHeaders("header1")
       .allowCredentials(false)
       .maxAge(1800) // seconds


### PR DESCRIPTION
具体修正以下内容：

1. [修正 st_attachment 建表 sql 语句错误](https://github.com/BallsperCat/simter-file/commit/aa82e1252cb773090e64a0f91de314fb61898417)
2. [优化修正 UploadFileByStreamHandler 类](https://github.com/BallsperCat/simter-file/commit/4b72a070442ace45a4636bca1b7e9867dbddc52d)
3. [优化修正 UploadFileByStreamHandler 类单元测试](https://github.com/BallsperCat/simter-file/commit/c1c7dab79ec9e6ae7bf6a280c04dcd020410e9cc)
4. [添加 Option 请求路由配置](https://github.com/BallsperCat/simter-file/commit/16bc779aa71c2b6e4f71d1a6fab61aeab38b826b)
5. [请求头验证允许 "Content-Type" 和 "Content-Disposition" 类型](https://github.com/BallsperCat/simter-file/commit/742b0c6495f3ad23896492374d40aeae1849224d)