### PR TITLE
添加文件服务器删除接口的实现和其他关联内容

### DIFF
--- a/simter-file-data-jpa/src/main/kotlin/tech/simter/file/dao/jpa/AttachmentDaoImpl.kt
+++ b/simter-file-data-jpa/src/main/kotlin/tech/simter/file/dao/jpa/AttachmentDaoImpl.kt
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
+import reactor.core.publisher.toFlux
 import tech.simter.file.dao.AttachmentDao
 import tech.simter.file.po.Attachment
 import javax.persistence.EntityManager
@@ -41,6 +42,13 @@ class AttachmentDaoImpl @Autowired constructor(
     val query: Query = em.createQuery(sql, Attachment::class.java).setParameter("puid", puid)
     if (hasSubgroup) query.setParameter("subgroup", subgroup)
     return Flux.fromIterable(query.resultList as List<Attachment>)
+  }
+
+  override fun find(vararg ids: String): Flux<Attachment> {
+    return ids.let {
+      if (it.isEmpty()) throw NullPointerException("The ids parameter must not be empty")
+      else repository.findAllById(ids.toList().asIterable()).toFlux()
+    }
   }
 
   override fun save(vararg attachments: Attachment): Mono<Void> {

--- a/simter-file-data-jpa/src/test/kotlin/tech/simter/file/dao/jpa/AttachmentDaoImplTest.kt
+++ b/simter-file-data-jpa/src/test/kotlin/tech/simter/file/dao/jpa/AttachmentDaoImplTest.kt
@@ -5,14 +5,19 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.data.domain.Sort.Direction.DESC
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.util.FileCopyUtils
 import reactor.test.StepVerifier
 import tech.simter.file.dao.AttachmentDao
 import tech.simter.file.po.Attachment
+import java.io.File
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.stream.IntStream
@@ -25,7 +30,9 @@ import kotlin.collections.ArrayList
  */
 @SpringJUnitConfig(ModuleConfiguration::class)
 @DataJpaTest
+@TestPropertySource(properties = ["simter.file.root=target/files"])
 class AttachmentDaoImplTest @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
   @PersistenceContext val em: EntityManager,
   val dao: AttachmentDao
 ) {
@@ -132,7 +139,7 @@ class AttachmentDaoImplTest @Autowired constructor(
   @Test
   fun findByIds() {
     // 1. mock
-    val ids = arrayOf("a0001","a0002","a0003","a0004","a0005")
+    val ids = arrayOf("a0001", "a0002", "a0003", "a0004", "a0005")
     val now = OffsetDateTime.now()
     val origin = ArrayList<Attachment>()
 
@@ -216,24 +223,30 @@ class AttachmentDaoImplTest @Autowired constructor(
     // 3. delete exists id
     // 3.1 prepare data
     val pos = (1..3).map {
-      Attachment(UUID.randomUUID().toString(), "/data", "Sample-$it", "png", 123, OffsetDateTime.now(), "Simter")
+      Attachment(UUID.randomUUID().toString(), "/data/$it.xml", "Sample-$it", "png", 123,
+        OffsetDateTime.now(), "Simter")
     }
+    val ids = pos.map { it.id }
     pos.forEach { em.persist(it) }
     em.flush()
     em.clear()
+    buildTestFiles(pos)
 
-    // 3.2 invoke
-    val ids = pos.map { it.id }
-    val actual = dao.delete(*ids.toTypedArray())
+    // 3.2 verify attachments is deleted
+    StepVerifier.create(dao.delete(*ids.toTypedArray())).verifyComplete()
+    StepVerifier.create(dao.find(*ids.toTypedArray())).expectNextCount(0L).verifyComplete()
 
-    // 3.3 verify empty result
-    StepVerifier.create(actual).expectNextCount(0L).verifyComplete()
+    // 3.3 verify physics files is deleted
+    pos.forEach { assertTrue(!File("$fileRootDir/${it.path}").exists()) }
+  }
 
-    // 3.4 verify deleted
-    assertEquals(
-      0L,
-      em.createQuery("select count(id) from Attachment where id in (:ids)")
-        .setParameter("ids", ids).singleResult
-    )
+  /** build test file method */
+  private fun buildTestFiles(attachments: List<Attachment>) {
+    attachments.forEach {
+      val file = File("$fileRootDir/${it.path}")
+      val parentFile = file.parentFile
+      if (!parentFile.exists()) parentFile.mkdirs()
+      FileCopyUtils.copy(ClassPathResource("banner.txt").file.readBytes(), file)
+    }
   }
 }

--- a/simter-file-data-reactive-mongo/src/main/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImpl.kt
+++ b/simter-file-data-reactive-mongo/src/main/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImpl.kt
@@ -1,6 +1,7 @@
 package tech.simter.file.dao.reactive.mongo
 
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
@@ -13,6 +14,7 @@ import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import tech.simter.file.dao.AttachmentDao
 import tech.simter.file.po.Attachment
+import java.io.File
 
 /**
  * The Reactive MongoDB implementation of [AttachmentDao].
@@ -21,6 +23,7 @@ import tech.simter.file.po.Attachment
  */
 @Component
 class AttachmentDaoImpl @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
   private val repository: AttachmentReactiveRepository,
   private val operations: ReactiveMongoOperations
 ) : AttachmentDao {
@@ -58,6 +61,12 @@ class AttachmentDaoImpl @Autowired constructor(
 
   override fun delete(vararg ids: String): Mono<Void> {
     return if (ids.isEmpty()) Mono.empty()
-    else repository.deleteAll(repository.findAllById(ids.asIterable()))
+    else repository.findAllById(ids.asIterable()).collectList().flatMap {
+      if (it.isEmpty()) Mono.empty<Void>()
+      // delete physics file
+      it.forEach { File("$fileRootDir/${it.path}").delete() }
+      // delete attachment in database
+      repository.deleteAll(it.asIterable())
+    }
   }
 }

--- a/simter-file-data-reactive-mongo/src/main/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImpl.kt
+++ b/simter-file-data-reactive-mongo/src/main/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImpl.kt
@@ -44,6 +44,13 @@ class AttachmentDaoImpl @Autowired constructor(
     return operations.find(Query.query(condition).with(Sort(Sort.Direction.DESC, "uploadOn")), Attachment::class.java)
   }
 
+  override fun find(vararg ids: String): Flux<Attachment> {
+    return ids.let {
+      if (it.isEmpty()) throw NullPointerException("The ids parameter must not be empty")
+      else repository.findAllById(ids.asIterable())
+    }
+  }
+
   override fun save(vararg attachments: Attachment): Mono<Void> {
     return if (attachments.isEmpty()) Mono.empty()
     else repository.saveAll(attachments.asIterable()).then()

--- a/simter-file-data-reactive-mongo/src/test/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImplTest.kt
+++ b/simter-file-data-reactive-mongo/src/test/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImplTest.kt
@@ -5,15 +5,20 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.mongodb.core.ReactiveMongoOperations
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.util.FileCopyUtils
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 import tech.simter.file.dao.AttachmentDao
 import tech.simter.file.po.Attachment
+import java.io.File
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.stream.IntStream
@@ -24,7 +29,9 @@ import java.util.stream.IntStream
  */
 @SpringJUnitConfig(ModuleConfiguration::class)
 @DataMongoTest
+@TestPropertySource(properties = ["simter.file.root=target/files"])
 class AttachmentDaoImplTest @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
   private val dao: AttachmentDao,
   private val operations: ReactiveMongoOperations
 ) {
@@ -116,7 +123,7 @@ class AttachmentDaoImplTest @Autowired constructor(
   }
 
   @Test
-  fun findByIds(){
+  fun findByIds() {
     // 1. mock
     val ids = arrayOf("a0001", "a0002", "a0003", "a0004", "a0005")
     val now = OffsetDateTime.now()
@@ -158,5 +165,41 @@ class AttachmentDaoImplTest @Autowired constructor(
     StepVerifier.create(operations.findById(po.id, Attachment::class.java))
       .expectNext(po)
       .verifyComplete()
+  }
+
+  @Test
+  fun delete() {
+    // 1. none
+    StepVerifier.create(dao.delete()).expectNextCount(0L).verifyComplete()
+
+    // 2. delete not exists id
+    StepVerifier.create(dao.delete(UUID.randomUUID().toString())).expectNextCount(0L).verifyComplete()
+
+    // 3. delete exists id
+    // 3.1 prepare data
+    val origin = (0..3).map {
+      Attachment(id = UUID.randomUUID().toString(), path = "$path/$it.xml", name = "Sample$it", ext = "png", size = 123,
+        uploadOn = now, uploader = uploader, puid = "puid1", subgroup = it.toShort())
+    }
+    val ids = origin.map { it.id }
+    StepVerifier.create(operations.insertAll(origin)).expectNextCount(origin.size.toLong()).verifyComplete()
+    buildTestFiles(origin)
+
+    // 3.2 verify attachments is deleted
+    StepVerifier.create(dao.delete(*ids.toTypedArray())).verifyComplete()
+    StepVerifier.create(dao.find(*ids.toTypedArray())).expectNextCount(0L).verifyComplete()
+
+    // 3.3 verify physics files is deleted
+    origin.forEach { Assertions.assertTrue(!File("$fileRootDir/${it.path}").exists()) }
+  }
+
+  /** build test file method */
+  private fun buildTestFiles(attachments: List<Attachment>) {
+    attachments.forEach {
+      val file = File("$fileRootDir/${it.path}")
+      val parentFile = file.parentFile
+      if (!parentFile.exists()) parentFile.mkdirs()
+      FileCopyUtils.copy(ClassPathResource("banner.txt").file.readBytes(), file)
+    }
   }
 }

--- a/simter-file-data/src/main/kotlin/tech/simter/file/dao/AttachmentDao.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/dao/AttachmentDao.kt
@@ -56,7 +56,7 @@ interface AttachmentDao {
   fun save(vararg attachments: Attachment): Mono<Void>
 
   /**
-   * Delete [Attachment] by its id.
+   * Delete [Attachment] and physics file by its id.
    *
    * @param[ids] the ids to delete
    * @return [Mono] signaling when operation has completed

--- a/simter-file-data/src/main/kotlin/tech/simter/file/dao/AttachmentDao.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/dao/AttachmentDao.kt
@@ -39,6 +39,15 @@ interface AttachmentDao {
   fun find(puid: String, subgroup: Short?): Flux<Attachment>
 
   /**
+   * Returns a [Flux] of [Attachment]'s by id array.
+   *
+   * @param[ids] the attachment identity array
+   * @return [Flux] emitting attachments or a empty flux without data if none found
+   * @throws [NullPointerException] if ids parameter had not data
+   */
+  fun find(vararg ids: String): Flux<Attachment>
+
+  /**
    * Create or update one or more [Attachment].
    *
    * @param[attachments] the attachments to save or update

--- a/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentService.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentService.kt
@@ -40,6 +40,15 @@ interface AttachmentService {
   fun find(puid: String, subgroup: Short?): Flux<Attachment>
 
   /**
+   * Returns a [Flux] of [Attachment]'s by id array.
+   *
+   * @param[ids] the attachment identity array
+   * @return [Flux] emitting attachments or a empty flux without data if none found
+   * @throws [NullPointerException] if ids parameter had not data
+   */
+  fun find(vararg ids: String): Flux<Attachment>
+
+  /**
    * Create or update one or more [Attachment].
    *
    * @param[attachments] the attachments to save or update

--- a/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentService.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentService.kt
@@ -57,7 +57,7 @@ interface AttachmentService {
   fun save(vararg attachments: Attachment): Mono<Void>
 
   /**
-   * Delete [Attachment] by its id.
+   * Delete [Attachment] and physics file by its id.
    *
    * @param[ids] the ids to delete
    * @return [Mono] signaling when operation has completed

--- a/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentServiceImpl.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentServiceImpl.kt
@@ -29,6 +29,10 @@ class AttachmentServiceImpl @Autowired constructor(val attachmentDao: Attachment
     return attachmentDao.find(puid, subgroup)
   }
 
+  override fun find(vararg ids: String): Flux<Attachment> {
+    return attachmentDao.find(*ids)
+  }
+
   override fun save(vararg attachments: Attachment): Mono<Void> {
     return attachmentDao.save(*attachments)
   }

--- a/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentServiceImpl.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentServiceImpl.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import tech.simter.file.dao.AttachmentDao
@@ -16,6 +17,7 @@ import tech.simter.file.po.Attachment
  * @author RJ
  */
 @Component
+@Transactional
 class AttachmentServiceImpl @Autowired constructor(val attachmentDao: AttachmentDao) : AttachmentService {
   override fun get(id: String): Mono<Attachment> {
     return attachmentDao.get(id)

--- a/simter-file-data/src/test/kotlin/tech/simter/file/service/AttachmentServiceImplTest.kt
+++ b/simter-file-data/src/test/kotlin/tech/simter/file/service/AttachmentServiceImplTest.kt
@@ -74,6 +74,21 @@ class AttachmentServiceImplTest @Autowired constructor(
   }
 
   @Test
+  fun findByIds() {
+    // mock
+    val ids = arrayOf("aaa", "bbb", "ccc")
+    val expect = Collections.emptyList<Attachment>()
+    `when`(dao.find(*ids)).thenReturn(Flux.fromIterable(expect))
+
+    // invoke
+    val actual = service.find(*ids)
+
+    // verify
+    StepVerifier.create(actual.collectList()).expectNext(expect).verifyComplete()
+    verify(dao).find(*ids)
+  }
+
+  @Test
   fun save() {
     // mock
     val attachment = Attachment(UUID.randomUUID().toString(), "/data", "Sample", "png", 123, OffsetDateTime.now(), "Simter")

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
@@ -34,7 +34,8 @@ class ModuleConfiguration @Autowired constructor(
   private val uploadFileByFormHandler: UploadFileByFormHandler,
   private val uploadFileByStreamHandler: UploadFileByStreamHandler,
   private val downloadFileHandler: DownloadFileHandler,
-  private val inlineFileHandler: InlineFileHandler
+  private val inlineFileHandler: InlineFileHandler,
+  private val deleteFilesHandler: DeleteFilesHandler
 ) {
   private val logger = LoggerFactory.getLogger(ModuleConfiguration::class.java)
 
@@ -62,6 +63,8 @@ class ModuleConfiguration @Autowired constructor(
       DownloadFileHandler.REQUEST_PREDICATE.invoke(downloadFileHandler::handle)
       // GET /inline/{id}
       InlineFileHandler.REQUEST_PREDICATE.invoke(inlineFileHandler::handle)
+      // DELETE /{ids}
+      DeleteFilesHandler.REQUEST_PREDICATE.invoke(deleteFilesHandler::handle)
       // GET /
       GET("/", { ok().contentType(TEXT_PLAIN).syncBody("simter-file-$version") })
       // OPTIONS /*

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandler.kt
@@ -2,6 +2,8 @@ package tech.simter.file.rest.webflux.handler
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.HandlerFunction
 import org.springframework.web.reactive.function.server.RequestPredicate
@@ -10,6 +12,7 @@ import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.ServerResponse
 import reactor.core.publisher.Mono
 import tech.simter.file.service.AttachmentService
+import java.io.File
 
 /**
  * The [HandlerFunction] for delete files.
@@ -43,7 +46,16 @@ class DeleteFilesHandler @Autowired constructor(
 ) : HandlerFunction<ServerResponse> {
 
   override fun handle(request: ServerRequest): Mono<ServerResponse> {
-    return Mono.empty()
+    return attachmentService.find(*request.pathVariable("ids").split(",").toTypedArray())
+      .collectList()
+      .flatMap({
+        attachmentService.delete(*it.map { it.id }.toTypedArray())
+        ServerResponse.noContent().build()
+      })
+      // error mapping
+      .onErrorResume(NoSuchFileException::class.java, {
+        ServerResponse.status(HttpStatus.NOT_FOUND).contentType(MediaType.TEXT_PLAIN).syncBody(it.message ?: "")
+      })
   }
 
   companion object {

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandler.kt
@@ -1,0 +1,53 @@
+package tech.simter.file.rest.webflux.handler
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.HandlerFunction
+import org.springframework.web.reactive.function.server.RequestPredicate
+import org.springframework.web.reactive.function.server.RequestPredicates.DELETE
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+import tech.simter.file.service.AttachmentService
+
+/**
+ * The [HandlerFunction] for delete files.
+ *
+ * Request:
+ *
+ * ```
+ * Delete {context-path}/{ids}
+ * ```
+ *
+ * Response: (if found)
+ *
+ * ```
+ * 204 No Content
+ * ```
+ *
+ * Response: (if not found)
+ *
+ * ```
+ * 404 Not Found
+ * ```
+ *
+ * [More](https://github.com/simter/simter-file/wiki/Delete-Files)
+ *
+ * @author JW
+ */
+@Component
+class DeleteFilesHandler @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
+  private val attachmentService: AttachmentService
+) : HandlerFunction<ServerResponse> {
+
+  override fun handle(request: ServerRequest): Mono<ServerResponse> {
+    return Mono.empty()
+  }
+
+  companion object {
+    /** The default [RequestPredicate] */
+    val REQUEST_PREDICATE: RequestPredicate = DELETE("/{ids}")
+  }
+}

--- a/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandlerTest.kt
+++ b/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandlerTest.kt
@@ -1,0 +1,77 @@
+package tech.simter.file.rest.webflux.handler
+
+import junit.framework.Assert.assertTrue
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.core.io.ClassPathResource
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFunction
+import org.springframework.util.FileCopyUtils
+import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.function.server.RouterFunctions.route
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import tech.simter.file.po.Attachment
+import tech.simter.file.rest.webflux.handler.DeleteFilesHandler.Companion.REQUEST_PREDICATE
+import tech.simter.file.service.AttachmentService
+import java.io.File
+import java.time.OffsetDateTime
+import java.util.*
+
+/**
+ * Test DeleteFilesHandler.
+ *
+ * @author JW
+ */
+@SpringJUnitConfig(DeleteFilesHandler::class)
+@EnableWebFlux
+@MockBean(AttachmentService::class)
+@TestPropertySource(properties = ["simter.file.root=target/files"])
+internal class DeleteFilesHandlerTest @Autowired constructor(
+  private val service: AttachmentService,
+  @Value("\${simter.file.root}") private val fileRootDir: String,
+  handler: DeleteFilesHandler
+) {
+  private val client = bindToRouterFunction(route(REQUEST_PREDICATE, handler)).build()
+
+  @Test
+  fun deleteOne() {
+    // mock
+    val id = UUID.randomUUID().toString()
+    val expect = Attachment(id = id, name = "1", ext = "xml", path = "201809/1.xml", puid = "puid1", subgroup = 1,
+      size = 123, uploadOn = OffsetDateTime.now(), uploader = "cjw")
+    `when`(service.find(id)).thenReturn(Flux.just(expect))
+    `when`(service.delete(id)).thenReturn(Mono.empty())
+
+    // invoke
+    client.delete().uri("/$id").exchange().expectStatus().isNoContent
+
+    // verify
+    Mockito.verify(service).find(id)
+    Mockito.verify(service).delete(id)
+  }
+
+  @Test
+  fun deleteBatch() {
+    // mock
+    val ids = arrayOf("a0001", "a0002", "a0003", "a0004", "a0005")
+    val expect = (0..ids.size.minus(1)).map {
+      Attachment(id = ids[it], name = "1", ext = "xml", path = "201809/$it.xml", puid = "puid1", subgroup = 1,
+        size = 123, uploadOn = OffsetDateTime.now(), uploader = "cjw")
+    }
+    `when`(service.find(*ids)).thenReturn(Flux.fromIterable(expect))
+    `when`(service.delete(*ids)).thenReturn(Mono.empty())
+
+    // invoke
+    client.delete().uri("/${ids.joinToString(",")}").exchange().expectStatus().isNoContent
+
+    // verify
+    Mockito.verify(service).find(*ids)
+    Mockito.verify(service).delete(*ids)
+  }
+}


### PR DESCRIPTION
本次修改了以下内容：

1. service、mongodbDao、jpaDao 添加通过 id 数组批量查询接口和实现和单元测试。
2. 添加 web-flux 的删除接口实现和单元测试。
3. dao 层删除接口实现添加同时删除物理文件功能