### PR TITLE
删除接口 Rest 实现和相关修改

### DIFF
--- a/simter-file-data-reactive-mongo/src/test/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImplTest.kt
+++ b/simter-file-data-reactive-mongo/src/test/kotlin/tech/simter/file/dao/reactive/mongo/AttachmentDaoImplTest.kt
@@ -5,15 +5,20 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest
+import org.springframework.core.io.ClassPathResource
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.mongodb.core.ReactiveMongoOperations
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.util.FileCopyUtils
 import reactor.core.publisher.Mono
 import reactor.test.StepVerifier
 import tech.simter.file.dao.AttachmentDao
 import tech.simter.file.po.Attachment
+import java.io.File
 import java.time.OffsetDateTime
 import java.util.*
 import java.util.stream.IntStream
@@ -24,7 +29,9 @@ import java.util.stream.IntStream
  */
 @SpringJUnitConfig(ModuleConfiguration::class)
 @DataMongoTest
+@TestPropertySource(properties = ["simter.file.root=target/files"])
 class AttachmentDaoImplTest @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
   private val dao: AttachmentDao,
   private val operations: ReactiveMongoOperations
 ) {
@@ -127,5 +134,40 @@ class AttachmentDaoImplTest @Autowired constructor(
     StepVerifier.create(operations.findById(po.id, Attachment::class.java))
       .expectNext(po)
       .verifyComplete()
+  }
+
+  @Test
+  fun delete() {
+    // 1. none
+    StepVerifier.create(dao.delete()).expectNextCount(0L).verifyComplete()
+
+    // 2. delete not exists id
+    StepVerifier.create(dao.delete(UUID.randomUUID().toString())).expectNextCount(0L).verifyComplete()
+
+    // 3. delete exists id
+    // 3.1 prepare data
+    val origin = (0..3).map {
+      Attachment(id = UUID.randomUUID().toString(), path = "$path/$it.xml", name = "Sample$it", ext = "png", size = 123,
+        uploadOn = now, uploader = uploader, puid = "puid1", subgroup = it.toShort())
+    }
+    val ids = origin.map { it.id }
+    StepVerifier.create(operations.insertAll(origin)).expectNextCount(origin.size.toLong()).verifyComplete()
+    buildTestFiles(origin)
+
+    // 3.2 verify attachments is deleted
+    StepVerifier.create(dao.delete(*ids.toTypedArray())).verifyComplete()
+
+    // 3.3 verify physics files is deleted
+    origin.forEach { Assertions.assertTrue(!File("$fileRootDir/${it.path}").exists()) }
+  }
+
+  /** build test file method */
+  private fun buildTestFiles(attachments: List<Attachment>) {
+    attachments.forEach {
+      val file = File("$fileRootDir/${it.path}")
+      val parentFile = file.parentFile
+      if (!parentFile.exists()) parentFile.mkdirs()
+      FileCopyUtils.copy(ClassPathResource("banner.txt").file.readBytes(), file)
+    }
   }
 }

--- a/simter-file-data/src/main/kotlin/tech/simter/file/dao/AttachmentDao.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/dao/AttachmentDao.kt
@@ -47,7 +47,8 @@ interface AttachmentDao {
   fun save(vararg attachments: Attachment): Mono<Void>
 
   /**
-   * Delete [Attachment] by its id.
+   * Delete [Attachment] and physics file by its id.
+   * If specify [Attachment] not exists then ignore and handle as success.
    *
    * @param[ids] the ids to delete
    * @return [Mono] signaling when operation has completed

--- a/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentService.kt
+++ b/simter-file-data/src/main/kotlin/tech/simter/file/service/AttachmentService.kt
@@ -48,7 +48,8 @@ interface AttachmentService {
   fun save(vararg attachments: Attachment): Mono<Void>
 
   /**
-   * Delete [Attachment] by its id.
+   * Delete [Attachment] and physics file by its id.
+   * If specify [Attachment] not exists then ignore and handle as success.
    *
    * @param[ids] the ids to delete
    * @return [Mono] signaling when operation has completed

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/ModuleConfiguration.kt
@@ -34,7 +34,8 @@ class ModuleConfiguration @Autowired constructor(
   private val uploadFileByFormHandler: UploadFileByFormHandler,
   private val uploadFileByStreamHandler: UploadFileByStreamHandler,
   private val downloadFileHandler: DownloadFileHandler,
-  private val inlineFileHandler: InlineFileHandler
+  private val inlineFileHandler: InlineFileHandler,
+  private val deleteFilesHandler: DeleteFilesHandler
 ) {
   private val logger = LoggerFactory.getLogger(ModuleConfiguration::class.java)
 
@@ -62,6 +63,8 @@ class ModuleConfiguration @Autowired constructor(
       DownloadFileHandler.REQUEST_PREDICATE.invoke(downloadFileHandler::handle)
       // GET /inline/{id}
       InlineFileHandler.REQUEST_PREDICATE.invoke(inlineFileHandler::handle)
+      // DELETE /{ids}
+      DeleteFilesHandler.REQUEST_PREDICATE.invoke(deleteFilesHandler::handle)
       // GET /
       GET("/", { ok().contentType(TEXT_PLAIN).syncBody("simter-file-$version") })
       // OPTIONS /*

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandler.kt
@@ -1,0 +1,48 @@
+package tech.simter.file.rest.webflux.handler
+
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.HandlerFunction
+import org.springframework.web.reactive.function.server.RequestPredicate
+import org.springframework.web.reactive.function.server.RequestPredicates.DELETE
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import reactor.core.publisher.Mono
+import tech.simter.file.service.AttachmentService
+
+/**
+ * The [HandlerFunction] for delete files.
+ *
+ * Request:
+ *
+ * ```
+ * Delete {context-path}/{ids}
+ * ```
+ *
+ * Response:
+ *
+ * ```
+ * 204 No Content
+ * ```
+ *
+ * [More](https://github.com/simter/simter-file/wiki/Delete-Files)
+ *
+ * @author JW
+ */
+@Component
+class DeleteFilesHandler @Autowired constructor(
+  @Value("\${simter.file.root}") private val fileRootDir: String,
+  private val attachmentService: AttachmentService
+) : HandlerFunction<ServerResponse> {
+
+  override fun handle(request: ServerRequest): Mono<ServerResponse> {
+    return attachmentService.delete(*request.pathVariable("ids").split(",").toTypedArray())
+      .then(ServerResponse.noContent().build())
+  }
+
+  companion object {
+    /** The default [RequestPredicate] */
+    val REQUEST_PREDICATE: RequestPredicate = DELETE("/{ids}")
+  }
+}

--- a/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandlerTest.kt
+++ b/simter-file-rest-webflux/src/test/kotlin/tech/simter/file/rest/webflux/handler/DeleteFilesHandlerTest.kt
@@ -1,0 +1,60 @@
+package tech.simter.file.rest.webflux.handler
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import org.mockito.Mockito.`when`
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.TestPropertySource
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig
+import org.springframework.test.web.reactive.server.WebTestClient.bindToRouterFunction
+import org.springframework.web.reactive.config.EnableWebFlux
+import org.springframework.web.reactive.function.server.RouterFunctions.route
+import reactor.core.publisher.Mono
+import tech.simter.file.rest.webflux.handler.DeleteFilesHandler.Companion.REQUEST_PREDICATE
+import tech.simter.file.service.AttachmentService
+import java.util.*
+
+/**
+ * Test [DeleteFilesHandler].
+ *
+ * @author JW
+ */
+@SpringJUnitConfig(DeleteFilesHandler::class)
+@EnableWebFlux
+@MockBean(AttachmentService::class)
+@TestPropertySource(properties = ["simter.file.root=target/files"])
+internal class DeleteFilesHandlerTest @Autowired constructor(
+  private val service: AttachmentService,
+  @Value("\${simter.file.root}") private val fileRootDir: String,
+  handler: DeleteFilesHandler
+) {
+  private val client = bindToRouterFunction(route(REQUEST_PREDICATE, handler)).build()
+
+  @Test
+  fun deleteOne() {
+    // mock
+    val id = UUID.randomUUID().toString()
+    `when`(service.delete(id)).thenReturn(Mono.empty())
+
+    // invoke
+    client.delete().uri("/$id").exchange().expectStatus().isNoContent
+
+    // verify
+    Mockito.verify(service).delete(id)
+  }
+
+  @Test
+  fun deleteBatch() {
+    // mock
+    val ids = arrayOf("a0001", "a0002", "a0003", "a0004", "a0005")
+    `when`(service.delete(*ids)).thenReturn(Mono.empty())
+
+    // invoke
+    client.delete().uri("/${ids.joinToString(",")}").exchange().expectStatus().isNoContent
+
+    // verify
+    Mockito.verify(service).delete(*ids)
+  }
+}


### PR DESCRIPTION
1. 删除接口 Rest 端实现和单元测试。
2. Service 和 Dao 删除接口设计补充“删除不存在的文件时忽略当作删除成功处理”。
3. 删除接口 MongoDB 实现同时删除文件。
4. 删除接口 JPA 实现同时删除文件。