### PR TITLE
Add 'size' to upload interface

### DIFF
--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DownloadHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/DownloadHandler.kt
@@ -135,7 +135,7 @@ class DownloadHandler @Autowired constructor(
   }
 
   private fun downloadByModule(request: ServerRequest): Mono<ServerResponse> {
-    val module = decodeParam(request.pathVariable("id"))
+    val module = request.pathVariable("id")
     return fileService.findList(ModuleMatcher.autoModuleMatcher(module))
       .collectList()
       .flatMap { fileViews ->

--- a/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/UploadHandler.kt
+++ b/simter-file-rest-webflux/src/main/kotlin/tech/simter/file/rest/webflux/handler/UploadHandler.kt
@@ -43,6 +43,7 @@ class UploadHandler @Autowired constructor(
     val module = request.queryParam("module").orElse("/default/")
     val name = request.queryParam("name").orElse("unknown")
     val type = request.queryParam("type").orElse("xyz")
+    val size = request.queryParam("size").orElse("0").toLong()
 
     // upload file
     val uploadResult = if (contentType.get().isCompatibleWith(MULTIPART_FORM_DATA)
@@ -62,7 +63,7 @@ class UploadHandler @Autowired constructor(
                     module = module,
                     name = name,
                     type = type,
-                    size = file.headers().contentLength
+                    size = if (size != 0L) size else file.headers().contentLength
                   ),
                   source = FileUploadSource.FromFilePart(file)
                 )


### PR DESCRIPTION
With request Content-Type `multipart/form-data' upload file，the back-end cannot obtain the file size by 'file.headers().contentLength'